### PR TITLE
Add GitHub Issue/PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+---
+name: Bug
+about: Use this template when reporting an issue with this orb
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Orb version
+
+<!---
+  e.g., 1.0.0
+  find this information in your config.yml file;
+  if the version is @volatile, check the top of your CircleCI-generated,
+  expanded configuration file, viewable from the "Configuration" tab of
+  any job page, for the orb's specific semantic version number
+-->
+
+### What happened
+
+<!---
+  please include any relevant links to CircleCI workflows or jobs
+  where you saw this behavior
+-->
+
+### Expected behavior
+
+<!--- what should happen, ideally? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+### Checklist
+
+<!--
+	thank you for contributing to CircleCI Orbs!
+	before submitting your a request, please go through the following
+	items and place an x in the [ ] if they have been completed
+-->
+
+- [ ] All new jobs, commands, executors, parameters have descriptions
+- [ ] Examples have been added for any significant new features
+- [ ] README has been updated, if necessary
+
+### Motivation, issues
+
+<!---
+	why is this change required? what problem does it solve?
+  paste links to any relevant GitHub issues filed against
+  this repository that this pull request addresses
+-->
+
+### Description
+
+<!---
+  Describe your changes in detail, preferably in an imperative mood,
+  i.e., "add `commandA` to `jobB`"
+ -->


### PR DESCRIPTION
This brings them into line with other Orb repositories that I have just sent PR's to update to latest standards.

For example, this PR:

https://github.com/CircleCI-Public/slack-orb/pull/88

The documentation for this GitHub feature can be found here:

https://help.github.com/en/articles/about-issue-and-pull-request-templates

### Related Pull Requests

I have opened similar PR's in other Orb Repositories:

https://github.com/CircleCI-Public/slack-orb/pull/88
https://github.com/CircleCI-Public/docker-orb/pull/23
https://github.com/CircleCI-Public/circleci-cli-orb/pull/2
https://github.com/CircleCI-Public/build-tools-orb/pull/15
https://github.com/CircleCI-Public/azure-cli-orb/pull/4
https://github.com/CircleCI-Public/artifactory-orb/pull/17