### PR TITLE
Remove needless backslashes from command descriptions

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -12,13 +12,13 @@ commands:
     parameters:
       from:
         description: >
-          This must be a Twilio phone number that you own, formatted with a '+' and country code, \
+          This must be a Twilio phone number that you own, formatted with a '+' and country code,
            e.g. +16175551212 (E.164 format). You can also use a Messaging Service SID.
         type: string
         default: ${TWILIO_FROM}
       to:
         description: >
-          This parameter determines the destination phone number for your SMS message. \
+          This parameter determines the destination phone number for your SMS message.
           Format this number with a '+' and a country code, e.g., +16175551212 (E.164 format).
         type: string
         default: ${TWILIO_TO}
@@ -48,13 +48,13 @@ commands:
     parameters:
       from:
         description: >
-          This must be a Twilio phone number that you own, formatted with a '+' and country code, \
+          This must be a Twilio phone number that you own, formatted with a '+' and country code,
            e.g. +16175551212 (E.164 format). You can also use a Messaging Service SID.
         type: string
         default: ${TWILIO_FROM}
       to:
         description: >
-          This parameter determines the destination phone number for your SMS message. \
+          This parameter determines the destination phone number for your SMS message.
           Format this number with a '+' and a country code, e.g., +16175551212 (E.164 format).
         type: string
         default: ${TWILIO_TO}


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Twillio Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
    - This PR does not add or change jobs, commands, executors or parameters.
- [x] Examples have been added for any significant new features
    - This PR does not add new features.
- [x] README has been updated, if necessary
    - Probably it is not necessary.

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Some unexpected backslashes sneaked in command descriptions in [the orb registry page](https://circleci.com/orbs/registry/orb/circleci/twilio#commands).

![descriptions](https://user-images.githubusercontent.com/2227862/66683452-6f784e80-ecb2-11e9-8817-9e381ac723eb.png)

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

These backslashes were probably added to escape newlines, but they are not needed because their block is in [a folded style](https://yaml.org/spec/1.2/spec.html#id2796251).